### PR TITLE
feat: queue requests client-side

### DIFF
--- a/dune
+++ b/dune
@@ -1,5 +1,19 @@
-(executables 
-  (names main) 
-  (libraries bonsai.web async_js yojson bonsai.web_ui_form bonsai.vdom_node_with_map_children bonsai.kado virtual_dom.svg) 
-  (modes js)
-  (preprocess (pps ppx_jane js_of_ocaml-ppx ppx_css ppx_typed_fields ppx_yojson_conv bonsai.ppx_bonsai)))
+(executables
+ (names main)
+ (libraries
+  bonsai.web
+  async_js
+  yojson
+  bonsai.web_ui_form
+  bonsai.vdom_node_with_map_children
+  bonsai.kado
+  virtual_dom.svg)
+ (modes js)
+ (preprocess
+  (pps
+   ppx_jane
+   js_of_ocaml-ppx
+   ppx_css
+   ppx_typed_fields
+   ppx_yojson_conv
+   bonsai.ppx_bonsai)))

--- a/gallery.ml
+++ b/gallery.ml
@@ -208,7 +208,9 @@ let component ~host_and_port ~set_params =
             if params.enable_hr
             then None
             else
-              lazy (queue_request { params with Txt2img.Query.seed = info.seed; enable_hr = true })
+              lazy
+                (queue_request
+                   { params with Txt2img.Query.seed = info.seed; enable_hr = true })
               |> Effect.lazy_
               |> Some
           in

--- a/gallery.mli
+++ b/gallery.mli
@@ -2,13 +2,8 @@ open! Core
 open! Bonsai_web
 
 type t =
-  { ongoing : bool
-  ; wrap_request : unit Effect.t -> unit Effect.t
-  ; add_images :
-      params:Txt2img.Query.t
-      -> images:(Base64_image.t * Txt2img.Info.t) Or_error.t list
-      -> unit Effect.t
-  ; view : preview:Vdom.Node.t option -> Vdom.Node.t
+  { queue_request : Txt2img.Query.t -> unit Effect.t
+  ; view : Vdom.Node.t
   }
 
 val component

--- a/main.ml
+++ b/main.ml
@@ -34,41 +34,29 @@ let blurry_transparent_background =
 ;;
 
 let component =
-  let%sub progress = Progress.state ~host_and_port in
-  let%sub { form; form_view; width; height } =
+  let%sub { form; form_view } =
     blurry_transparent_background (Parameters.component ~host_and_port)
   in
-  let%sub { ongoing; wrap_request; add_images; view = elements } =
+  let%sub { queue_request; view = gallery } =
     Gallery.component ~host_and_port ~set_params:(form >>| Form.set)
-  in
-  let%sub preview =
-    Preview.component ~width ~height ~ongoing progress
   in
   let%sub submit_effect =
     let%sub form = Bonsai.yoink form in
     let%arr form = form
-    and add_images = add_images
-    and host_and_port = host_and_port
-    and wrap_request = wrap_request in
+    and queue_request = queue_request in
     Some
-      (wrap_request
-         (match%bind.Effect form with
-          | Inactive -> Effect.Ignore
-          | Active form ->
-            (match Form.value form with
-             | Error e -> Effect.print_s [%sexp (e : Error.t)]
-             | Ok query ->
-               (match%bind.Effect Txt2img.dispatch ~host_and_port query with
-                | Ok images ->
-                  add_images ~params:query ~images:(List.map images ~f:Result.return)
-                | Error e -> add_images ~params:query ~images:[ Error e ]))))
+      (match%bind.Effect form with
+       | Inactive -> Effect.Ignore
+       | Active form ->
+         (match Form.value form with
+          | Error e -> Effect.print_s [%sexp (e : Error.t)]
+          | Ok query -> queue_request query))
   in
-  let%arr preview = preview
-  and form_view = form_view
+  let%arr form_view = form_view
   and submit_effect = submit_effect
-  and elements = elements in
+  and gallery = gallery in
   let on_submit = Option.value submit_effect ~default:Effect.Ignore in
-  Vdom.Node.div [ form_view ~on_submit; elements ~preview ]
+  Vdom.Node.div [ form_view ~on_submit; gallery ]
 ;;
 
 let () =

--- a/parameters.ml
+++ b/parameters.ml
@@ -7,8 +7,6 @@ module Form = Bonsai_web_ui_form
 type t =
   { form : Txt2img.Query.t Form.t
   ; form_view : on_submit:unit Effect.t -> Vdom.Node.t
-  ; width : Int63.t
-  ; height : Int63.t
   }
 
 module Size_presets = struct
@@ -283,11 +281,7 @@ let component ~host_and_port =
             ]
         ]
   in
-  let%arr width = width_form
-  and height = height_form
-  and form = form
+  let%arr form = form
   and form_view = form_view in
-  let width = Form.value_or_default width ~default:(Int63.of_int 128) in
-  let height = Form.value_or_default height ~default:(Int63.of_int 128) in
-  { form; form_view; width; height }
+  { form; form_view }
 ;;

--- a/parameters.mli
+++ b/parameters.mli
@@ -6,8 +6,6 @@ module Form := Bonsai_web_ui_form
 type t =
   { form : Txt2img.Query.t Form.t
   ; form_view : on_submit:unit Effect.t -> Vdom.Node.t
-  ; width : Int63.t
-  ; height : Int63.t
   }
 
 val component : host_and_port:string Value.t -> t Computation.t

--- a/preview.ml
+++ b/preview.ml
@@ -2,29 +2,24 @@ open! Core
 open! Bonsai_web
 open Bonsai.Let_syntax
 
-let component ~width ~height ~ongoing progress =
-  let view ~reset =
-    match%sub ongoing with
-    | false -> Bonsai.const None
-    | true ->
-      let%sub () = Bonsai.Edge.lifecycle ~on_deactivate:reset () in
-      let%sub width, height = Bonsai.freeze (Value.both width height) in
-      (match%sub progress with
-       | Error _ -> Bonsai.const None
-       | Ok { Progress.current_image; progress; _ } ->
-         let%arr current_image = current_image
-         and width = width
-         and height = height
-         and progress = progress in
-         let image_view =
-           match current_image with
-           | Some b64_image -> Base64_image.to_vdom b64_image ~width ~height
-           | None -> Vdom.Node.p [ Vdom.Node.text "preparing image..." ]
-         in
-         let info_view =
-           Vdom.Node.p [ Vdom.Node.textf "%.1f%% complete" (progress *. 100.) ]
-         in
-         Some (View.vbox [ image_view; info_view ]))
-  in
-  Bonsai.with_model_resetter' view
+let component ~ongoing progress =
+  match%sub ongoing with
+  | None -> Bonsai.const None
+  | Some { Txt2img.Query.width; height; _ } ->
+    (match%sub progress with
+     | Error _ -> Bonsai.const None
+     | Ok { Progress.current_image; progress; _ } ->
+       let%arr current_image = current_image
+       and width = width
+       and height = height
+       and progress = progress in
+       let image_view =
+         match current_image with
+         | Some b64_image -> Base64_image.to_vdom b64_image ~width ~height
+         | None -> Vdom.Node.p [ Vdom.Node.text "preparing image..." ]
+       in
+       let info_view =
+         Vdom.Node.p [ Vdom.Node.textf "%.1f%% complete" (progress *. 100.) ]
+       in
+       Some (View.vbox [ image_view; info_view ]))
 ;;

--- a/preview.ml
+++ b/preview.ml
@@ -2,24 +2,35 @@ open! Core
 open! Bonsai_web
 open Bonsai.Let_syntax
 
-let component ~ongoing progress =
-  match%sub ongoing with
-  | None -> Bonsai.const None
-  | Some { Txt2img.Query.width; height; _ } ->
-    (match%sub progress with
-     | Error _ -> Bonsai.const None
-     | Ok { Progress.current_image; progress; _ } ->
-       let%arr current_image = current_image
-       and width = width
-       and height = height
-       and progress = progress in
-       let image_view =
-         match current_image with
-         | Some b64_image -> Base64_image.to_vdom b64_image ~width ~height
-         | None -> Vdom.Node.p [ Vdom.Node.text "preparing image..." ]
-       in
-       let info_view =
-         Vdom.Node.p [ Vdom.Node.textf "%.1f%% complete" (progress *. 100.) ]
-       in
-       Some (View.vbox [ image_view; info_view ]))
+let swap_opt_val = function
+  | None -> Value.return None
+  | Some v -> Value.map v ~f:Option.some
+;;
+
+let component ?params progress =
+  let params = swap_opt_val params in
+  match%sub progress with
+  | Error _ -> Bonsai.const None
+  | Ok { Progress.current_image; progress; _ } ->
+    let%sub image_view =
+      let%arr current_image = current_image
+      and params = params in
+      match current_image, params with
+      | Some b64_image, Some { Txt2img.Query.width; height; _ } ->
+        Base64_image.to_vdom b64_image ~width ~height
+      | Some b64_image, None -> Base64_image.to_vdom b64_image
+      | None, _ -> Vdom.Node.p [ Vdom.Node.text "preparing image..." ]
+    in
+    let%arr progress = progress
+    and image_view = image_view
+    and params = params in
+    let info_view =
+      Vdom.Node.p [ Vdom.Node.textf "%.1f%% complete" (progress *. 100.) ]
+    in
+    let prior_session_view =
+      match params with
+      | None -> Vdom.Node.p [ Vdom.Node.text "(from prior session)" ]
+      | Some _ -> Vdom.Node.none
+    in
+    Some (View.vbox [ image_view; info_view; prior_session_view ])
 ;;

--- a/preview.mli
+++ b/preview.mli
@@ -2,6 +2,6 @@ open! Core
 open! Bonsai_web
 
 val component
-  : ongoing: Txt2img.Query.t option Value.t
+  :  ?params:Txt2img.Query.t Value.t
   -> Progress.t Or_error.t Value.t
   -> Vdom.Node.t option Computation.t

--- a/preview.mli
+++ b/preview.mli
@@ -2,8 +2,6 @@ open! Core
 open! Bonsai_web
 
 val component
-  :  width:Int63.t Value.t
-  -> height:Int63.t Value.t
-  -> ongoing: bool Value.t
+  : ongoing: Txt2img.Query.t option Value.t
   -> Progress.t Or_error.t Value.t
   -> Vdom.Node.t option Computation.t

--- a/request_queue.ml
+++ b/request_queue.ml
@@ -1,0 +1,115 @@
+open! Core
+open! Bonsai_web
+open Bonsai.Let_syntax
+
+module Style =
+  [%css
+  stylesheet
+    {|
+.container {
+    position: fixed;
+    bottom: 0;
+    right: 0;
+    max-height:50%;
+    overflow-y: scroll;
+    overflow-x: hidden;
+    border-radius: 9px;
+    border: 1px solid rgb(49, 57, 67);
+    padding-left: 20px;
+  }
+
+.queued_item {
+  border-bottom: 1px solid rgb(49, 57, 67);
+}
+
+.remove_queued_button {
+  margin-left: 20px;
+}
+|}]
+
+type t =
+  { view : Vdom.Node.t
+  ; preview_view : Vdom.Node.t option
+  ; queue_request : Txt2img.Query.t -> unit Effect.t
+  }
+
+let component ~host_and_port ~add_images =
+  let%sub ongoing, set_ongoing = Bonsai.state_opt () in
+  let%sub (_, requests), modify_requests =
+    (* TODO: allow reordering requests by reinserting the key as the average of the new neighbor keys. *)
+    Bonsai.state_machine0
+      ~default_model:(0., Map.empty (module Float))
+      ~apply_action:(fun _ctx (next_idx, map) -> function
+        | `Queue params -> next_idx +. 100., Map.add_exn map ~key:next_idx ~data:params
+        | `Pop idx -> next_idx, Map.remove map idx)
+      ()
+  in
+  let%sub next_request =
+    let%arr requests = requests in
+    Map.min_elt requests
+  in
+  let%sub handle_queue_effect =
+    let%arr ongoing = ongoing
+    and set_ongoing = set_ongoing
+    and next_request = next_request
+    and modify_requests = modify_requests
+    and host_and_port = host_and_port
+    and add_images = add_images in
+    match ongoing, next_request with
+    | Some _, _ | None, None -> Effect.Ignore
+    | None, Some (idx, params) ->
+      let open Effect.Let_syntax in
+      let%bind () = set_ongoing (Some params) in
+      let%bind () = modify_requests (`Pop idx) in
+      let%bind result =
+        match%bind Txt2img.dispatch ~host_and_port params with
+        | Ok images -> add_images ~params ~images:(List.map images ~f:Result.return)
+        | Error e -> add_images ~params ~images:[ Error e ]
+      in
+      let%bind () = set_ongoing None in
+      return result
+  in
+  let%sub () =
+    Bonsai.Clock.every
+      ~when_to_start_next_effect:`Every_multiple_of_period_blocking
+      ~trigger_on_activate:true
+      (Time_ns.Span.of_sec 0.1)
+      handle_queue_effect
+  in
+  let%sub requests =
+    Bonsai.assoc
+      (module Float)
+      requests
+      ~f:(fun idx request ->
+        let%arr idx = idx
+        and request = request
+        and modify_requests = modify_requests in
+        View.hbox
+          [ Vdom.Node.div ~attrs:[Style.queued_item] [Vdom.Node.sexp_for_debugging ([%sexp_of: Txt2img.Query.t] request)]
+          ; Vdom.Node.button
+              ~attrs:[ Style.remove_queued_button; Vdom.Attr.on_click (fun _ -> modify_requests (`Pop idx)) ]
+              [ Vdom.Node.text "X" ]
+          ])
+  in
+  let%sub view =
+    let%arr requests = requests in
+    if Map.is_empty requests
+    then Vdom.Node.None
+    else
+      View.vbox
+        ~attrs:[ Style.container ]
+        [ Vdom.Node.h2 [ Vdom.Node.text "Request Queue" ]
+        ; Vdom_node_with_map_children.make ~tag:"div" requests
+        ]
+  in
+  let%sub progress = Progress.state ~host_and_port in
+  let%sub preview_view = Preview.component ~ongoing progress in
+  let%sub queue_request =
+    let%arr modify_requests = modify_requests in
+    fun params -> modify_requests (`Queue params)
+  in
+  let%arr view = view
+  and preview_view = preview_view
+  and queue_request = queue_request in
+  { view; preview_view; queue_request }
+;;

--- a/request_queue.ml
+++ b/request_queue.ml
@@ -130,8 +130,8 @@ let component ~host_and_port ~add_images =
   let%sub preview_view =
     match%sub ongoing with
     | `Uninitialized | `Idle -> Bonsai.const None
-    | `Preexisting ->  Preview.component progress
-    | `Running params ->  Preview.component ~params progress
+    | `Preexisting -> Preview.component progress
+    | `Running params -> Preview.component ~params progress
   in
   let%sub queue_request =
     let%arr modify_requests = modify_requests in

--- a/request_queue.mli
+++ b/request_queue.mli
@@ -12,5 +12,6 @@ val component
   -> add_images:
        (params:Txt2img.Query.t
         -> images:(Base64_image.t * Txt2img.Info.t) Or_error.t list
-        -> unit Effect.t) Value.t
+        -> unit Effect.t)
+       Value.t
   -> t Computation.t

--- a/request_queue.mli
+++ b/request_queue.mli
@@ -1,0 +1,16 @@
+open! Core
+open! Bonsai_web
+
+type t =
+  { view : Vdom.Node.t
+  ; preview_view : Vdom.Node.t option
+  ; queue_request : Txt2img.Query.t -> unit Effect.t
+  }
+
+val component
+  :  host_and_port:string Value.t
+  -> add_images:
+       (params:Txt2img.Query.t
+        -> images:(Base64_image.t * Txt2img.Info.t) Or_error.t list
+        -> unit Effect.t) Value.t
+  -> t Computation.t


### PR DESCRIPTION
This simplifies the gallery, preview, and main component. It also allows users to keep track of (and cancel!) pending requests. It's also a step towards potentially supporting Img2Img as well, since the `params` stored in `ongoing` and `requests` can just be replaced with a `Text of Txt2Img.Query.t | Img of Img2Img.Query.t` union type.

The biggest missing piece (other than styling) is if there is already a request running when the app is started; e.g. if the page was refreshed with requests still processing / in the queue. This can be handled by adding an "on activate" effect to `request_queue` that blocks the queue dispatcher, checks for progress, and if anything is found, sets `ongoing` to "`Preoccupied", which should reflect in the preview accordingly.

![image](https://github.com/TyOverby/sdui/assets/38059171/0021f09e-515f-4838-90a5-11ed2f1ef913)
